### PR TITLE
Fix Material UI client side styles not working properly (resolved)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,8 +15,8 @@ const App : React.FC<AppProps> = (props: AppProps) => {
     useEffect(() => {
         const jssStyles = document.querySelector('#jss-server-side')
         if (jssStyles) {
-            if (document.parentElement) {
-                document.parentElement.removeChild(jssStyles)
+            if (jssStyles.parentElement) {
+                jssStyles.parentElement.removeChild(jssStyles)
             }
         }
     }, [])

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,7 +4,6 @@ import { ServerStyleSheets as MuiServerStyleSheets } from '@material-ui/core/sty
 
 export default class CustomDocument extends Document {
     static async getInitialProps(ctx) {
-
         const sheets = {
             styled: new StyledServerStyleSheet(),
             mui: new MuiServerStyleSheets()

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,8 @@ import axios from 'axios'
 import Head from 'next/head'
 import styled from 'styled-components'
 
+import { ServerStyleSheets as MuiServerStyleSheets } from '@material-ui/core/styles';
+
 import {
     Button,
     Box,
@@ -26,7 +28,6 @@ const Home = (props: HomeProps) => {
                     <link rel="preconnect" href="https://fonts.gstatic.com" />
                     <link href="https://fonts.googleapis.com/css2?family=Raleway&display=swap" rel="stylesheet" />
                 </Head>
-                <Button>Test</Button>
                 <MovieList
                     sectionTitle="Latest Releases"
                     sectionDescription=""


### PR DESCRIPTION
Making note of the issue for future reference.

### Summary

jss server side rendered styles were not removed properly causing side effects navigating between pages. 

**Note:** It is important to remove ssr generated to avoid side effect when client side re-generates the styles (via hydration or w/e). 

Likely what happened was during client hydration the CSS didn't load the override due to the button styles already existing from the ssr. 

### Bug

**Flow 1:**
1. Visit Home `/` (ssr)
2. Navigate  to Movie details `/movies/{moveId}` (client side navigation) 
3. Observe Button override (Material UI) not being loaded properly (or not even loaded at all) 

**Flow 2:**

1. Navigate directly to  `/movies/{moveId}` (ssr)
2. Observe Button override loads properly
